### PR TITLE
Add Actions for commit test and nightly artifact build

### DIFF
--- a/.github/workflows/graphql-server.yml
+++ b/.github/workflows/graphql-server.yml
@@ -1,0 +1,39 @@
+# This workflow uses actions that are not certified by GitHub.
+# They are provided by a third-party and are governed by
+# separate terms of service, privacy policy, and support
+# documentation.
+# This workflow will build a Java project with Gradle and cache/restore any dependencies to improve the workflow execution time
+# For more information see: https://help.github.com/actions/language-and-framework-guides/building-and-testing-java-with-gradle
+
+name: Build GraphQL-Server
+
+on:
+  push:
+    branches: [ "master" ]
+  pull_request:
+    branches: [ "master" ]
+
+permissions:
+  contents: read
+
+jobs:
+  build:
+
+    runs-on: ubuntu-latest
+
+    steps:
+    - uses: actions/checkout@v3
+    - name: Set up JDK 11
+      uses: actions/setup-java@v3
+      with:
+        java-version: '11'
+        distribution: 'temurin'
+    - name: make gradle wrapper executable
+      run: chmod +x ./gradlew
+    - name: build
+      run: ./gradlew :graphql-server:build
+    - name: capture build artifacts
+      uses: actions/upload-artifact@v2
+      with:
+        name: Artifacts
+        path: graphql-server/build/libs/


### PR DESCRIPTION
Added Actions scripts to test commits and build nightly artifacts.

Only Application subprojects are available for now, including `graphql-server`, `composer-client`.